### PR TITLE
Allow network_mode to be used in a step

### DIFF
--- a/pipeline/backend/docker/convert.go
+++ b/pipeline/backend/docker/convert.go
@@ -50,11 +50,11 @@ func toHostConfig(proc *backend.Step) *container.HostConfig {
 	// if len(proc.VolumesFrom) != 0 {
 	// 	config.VolumesFrom = proc.VolumesFrom
 	// }
-	// if len(proc.Network) != 0 {
-	// 	config.NetworkMode = container.NetworkMode(
-	// 		proc.Network,
-	// 	)
-	// }
+        if len(proc.NetworkMode) != 0 {
+                config.NetworkMode = container.NetworkMode(
+                        proc.NetworkMode,
+                )
+        }
 	if len(proc.DNS) != 0 {
 		config.DNS = proc.DNS
 	}

--- a/pipeline/backend/docker/convert.go
+++ b/pipeline/backend/docker/convert.go
@@ -50,11 +50,11 @@ func toHostConfig(proc *backend.Step) *container.HostConfig {
 	// if len(proc.VolumesFrom) != 0 {
 	// 	config.VolumesFrom = proc.VolumesFrom
 	// }
-        if len(proc.NetworkMode) != 0 {
-                config.NetworkMode = container.NetworkMode(
-                        proc.NetworkMode,
-                )
-        }
+	if len(proc.NetworkMode) != 0 {
+		config.NetworkMode = container.NetworkMode(
+			proc.NetworkMode,
+		)
+	}
 	if len(proc.DNS) != 0 {
 		config.DNS = proc.DNS
 	}

--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -103,14 +103,16 @@ func (e *engine) Exec(proc *backend.Step) error {
 		return err
 	}
 
-	for _, net := range proc.Networks {
-		err = e.client.NetworkConnect(ctx, net.Name, proc.Name, &network.EndpointSettings{
-			Aliases: net.Aliases,
-		})
-		if err != nil {
-			return err
-		}
-	}
+        if len(proc.NetworkMode) == 0 {
+                for _, net := range proc.Networks {
+                        err = e.client.NetworkConnect(ctx, net.Name, proc.Name, &network.EndpointSettings{
+                                Aliases: net.Aliases,
+                        })
+                        if err != nil {
+                                return err
+                        }
+                }
+        }
 
 	// if proc.Network != "host" { // or bridge, overlay, none, internal, container:<name> ....
 	// 	err = e.client.NetworkConnect(ctx, proc.Network, proc.Name, &network.EndpointSettings{

--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -103,16 +103,16 @@ func (e *engine) Exec(proc *backend.Step) error {
 		return err
 	}
 
-        if len(proc.NetworkMode) == 0 {
-                for _, net := range proc.Networks {
-                        err = e.client.NetworkConnect(ctx, net.Name, proc.Name, &network.EndpointSettings{
-                                Aliases: net.Aliases,
-                        })
-                        if err != nil {
-                                return err
-                        }
-                }
-        }
+	if len(proc.NetworkMode) == 0 {
+		for _, net := range proc.Networks {
+			err = e.client.NetworkConnect(ctx, net.Name, proc.Name, &network.EndpointSettings{
+				Aliases: net.Aliases,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	// if proc.Network != "host" { // or bridge, overlay, none, internal, container:<name> ....
 	// 	err = e.client.NetworkConnect(ctx, proc.Network, proc.Name, &network.EndpointSettings{

--- a/pipeline/backend/types.go
+++ b/pipeline/backend/types.go
@@ -44,6 +44,7 @@ type (
 		OnFailure    bool              `json:"on_failure,omitempty"`
 		OnSuccess    bool              `json:"on_success,omitempty"`
 		AuthConfig   Auth              `json:"auth_config,omitempty"`
+                NetworkMode  string            `json:"network_mode,omitempty"`
 	}
 
 	// Auth defines registry authentication credentials.

--- a/pipeline/backend/types.go
+++ b/pipeline/backend/types.go
@@ -44,7 +44,7 @@ type (
 		OnFailure    bool              `json:"on_failure,omitempty"`
 		OnSuccess    bool              `json:"on_success,omitempty"`
 		AuthConfig   Auth              `json:"auth_config,omitempty"`
-                NetworkMode  string            `json:"network_mode,omitempty"`
+		NetworkMode  string            `json:"network_mode,omitempty"`
 	}
 
 	// Auth defines registry authentication credentials.

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -19,6 +19,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container) *backen
 		entrypoint = container.Entrypoint
 		command    = container.Command
 		image      = expandImage(container.Image)
+                network_mode = container.NetworkMode
 		// network    = container.Network
 	)
 
@@ -137,6 +138,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container) *backen
 		OnFailure: (len(container.Constraints.Status.Include)+
 			len(container.Constraints.Status.Exclude) != 0) &&
 			container.Constraints.Status.Match("failure"),
+                NetworkMode:  network_mode,
 	}
 }
 

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -14,12 +14,12 @@ func (c *Compiler) createProcess(name string, container *yaml.Container) *backen
 		detached   bool
 		workingdir string
 
-		workspace  = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
-		privileged = container.Privileged
-		entrypoint = container.Entrypoint
-		command    = container.Command
-		image      = expandImage(container.Image)
-                network_mode = container.NetworkMode
+		workspace    = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
+		privileged   = container.Privileged
+		entrypoint   = container.Entrypoint
+		command      = container.Command
+		image        = expandImage(container.Image)
+		network_mode = container.NetworkMode
 		// network    = container.Network
 	)
 
@@ -138,7 +138,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container) *backen
 		OnFailure: (len(container.Constraints.Status.Include)+
 			len(container.Constraints.Status.Exclude) != 0) &&
 			container.Constraints.Status.Match("failure"),
-                NetworkMode:  network_mode,
+		NetworkMode: network_mode,
 	}
 }
 

--- a/pipeline/frontend/yaml/config.go
+++ b/pipeline/frontend/yaml/config.go
@@ -18,6 +18,7 @@ type (
 		Clone     Containers
 		Pipeline  Containers
 		Services  Containers
+                NetworkMode string
 		Networks  Networks
 		Volumes   Volumes
 		Labels    libcompose.SliceorMap

--- a/pipeline/frontend/yaml/config.go
+++ b/pipeline/frontend/yaml/config.go
@@ -12,16 +12,16 @@ import (
 type (
 	// Config defines a pipeline configuration.
 	Config struct {
-		Platform  string
-		Branches  Constraint
-		Workspace Workspace
-		Clone     Containers
-		Pipeline  Containers
-		Services  Containers
-                NetworkMode string
-		Networks  Networks
-		Volumes   Volumes
-		Labels    libcompose.SliceorMap
+		Platform    string
+		Branches    Constraint
+		Workspace   Workspace
+		Clone       Containers
+		Pipeline    Containers
+		Services    Containers
+		NetworkMode string
+		Networks    Networks
+		Volumes     Volumes
+		Labels      libcompose.SliceorMap
 	}
 
 	// Workspace defines a pipeline workspace.

--- a/pipeline/frontend/yaml/config_test.go
+++ b/pipeline/frontend/yaml/config_test.go
@@ -35,6 +35,7 @@ func xTestParse(t *testing.T) {
 				g.Assert(out.Pipeline.Containers[1].Commands).Equal(yaml.Stringorslice{"go build"})
 				g.Assert(out.Pipeline.Containers[2].Name).Equal("notify")
 				g.Assert(out.Pipeline.Containers[2].Image).Equal("slack")
+                                g.Assert(out.Pipeline.Containers[2].NetworkMode).Equal("container:name")
 				g.Assert(out.Labels["com.example.team"]).Equal("frontend")
 				g.Assert(out.Labels["com.example.type"]).Equal("build")
 			})
@@ -71,6 +72,7 @@ pipeline:
       - go test
   build:
     image: golang
+    network_mode: container:name
     commands:
       - go build
     when:

--- a/pipeline/frontend/yaml/config_test.go
+++ b/pipeline/frontend/yaml/config_test.go
@@ -35,7 +35,7 @@ func xTestParse(t *testing.T) {
 				g.Assert(out.Pipeline.Containers[1].Commands).Equal(yaml.Stringorslice{"go build"})
 				g.Assert(out.Pipeline.Containers[2].Name).Equal("notify")
 				g.Assert(out.Pipeline.Containers[2].Image).Equal("slack")
-                                g.Assert(out.Pipeline.Containers[2].NetworkMode).Equal("container:name")
+				g.Assert(out.Pipeline.Containers[2].NetworkMode).Equal("container:name")
 				g.Assert(out.Labels["com.example.team"]).Equal("frontend")
 				g.Assert(out.Labels["com.example.type"]).Equal("build")
 			})

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -88,6 +88,10 @@ func TestLintErrors(t *testing.T) {
 			from: "pipeline: { build: { image: golang, volumes: [ '/opt/data:/var/lib/mysql' ] }  }",
 			want: "Insufficient privileges to use volumes",
 		},
+		{
+			from: "pipeline: { build: { image: golang, network_mode: 'container:name' }  }",
+			want: "Insufficient privileges to use network_mode",
+		},
 		// cannot override entypoint, command for script steps
 		{
 			from: "pipeline: { build: { image: golang, commands: [ 'go build' ], entrypoint: [ '/bin/bash' ] } }",

--- a/samples/sample_8_network_mode/README.md
+++ b/samples/sample_8_network_mode/README.md
@@ -1,0 +1,18 @@
+Compile the yaml to the intermediate representation:
+
+```
+pipec compile
+```
+
+Execute the intermediate representation:
+
+```
+pipec exec
+```
+
+This example shows how to use the network_mode option to use the network defined
+by other container. This is useful for example to allow the CI to connect with servers
+behind a VPN.
+
+Before to start you need to create a container that connects to the VPN (using one of
+the openvpn client images like https://github.com/ekristen/docker-openvpn-client).

--- a/samples/sample_8_network_mode/pipeline.json
+++ b/samples/sample_8_network_mode/pipeline.json
@@ -1,0 +1,115 @@
+{
+  "pipeline": [
+    {
+      "name": "pipeline_clone_0",
+      "alias": "git",
+      "steps": [
+        {
+          "name": "pipeline_clone_0",
+          "alias": "git",
+          "image": "plugins/git:latest",
+          "working_dir": "/go/src/github.com/drone/envsubst",
+          "environment": {
+            "CI": "drone",
+            "CI_SCRIPT": "CmlmIFsgLW4gIiRDSV9ORVRSQ19NQUNISU5FIiBdOyB0aGVuCmNhdCA8PEVPRiA+ICRIT01FLy5uZXRyYwptYWNoaW5lICRDSV9ORVRSQ19NQUNISU5FCmxvZ2luICRDSV9ORVRSQ19VU0VSTkFNRQpwYXNzd29yZCAkQ0lfTkVUUkNfUEFTU1dPUkQKRU9GCmNobW9kIDA2MDAgJEhPTUUvLm5ldHJjCmZpCnVuc2V0IENJX05FVFJDX1VTRVJOQU1FCnVuc2V0IENJX05FVFJDX1BBU1NXT1JECnVuc2V0IENJX1NDUklQVAp1bnNldCBEUk9ORV9ORVRSQ19VU0VSTkFNRQp1bnNldCBEUk9ORV9ORVRSQ19QQVNTV09SRAoKZWNobyArICJzbGVlcCAxIgpzbGVlcCAxCgo=",
+            "CI_SYSTEM": "pipec",
+            "CI_SYSTEM_ARCH": "linux/amd64",
+            "CI_SYSTEM_LINK": "https://github.com/cncd/pipec",
+            "CI_SYSTEM_NAME": "pipec",
+            "CI_WORKSPACE": "/go/src/github.com/drone/envsubst",
+            "DRONE": "true",
+            "DRONE_ARCH": "linux/amd64",
+            "DRONE_BUILD_LINK": "https://github.com/cncd/pipec//0",
+            "DRONE_REPO_SCM": "git",
+            "DRONE_WORKSPACE": "/go/src/github.com/drone/envsubst",
+            "HOME": "/root",
+            "PLUGIN_DEPTH": "50",
+            "SHELL": "/bin/sh"
+          },
+          "entrypoint": [
+            "/bin/sh",
+            "-c"
+          ],
+          "command": [
+            "echo $CI_SCRIPT | base64 -d | /bin/sh -e"
+          ],
+          "volumes": [
+            "pipeline_default:/go"
+          ],
+          "networks": [
+            {
+              "name": "pipeline_default",
+              "aliases": [
+                "git"
+              ]
+            }
+          ],
+          "on_success": true,
+          "auth_config": {}
+        }
+      ]
+    },
+    {
+      "name": "pipeline_stage_0",
+      "alias": "build",
+      "steps": [
+        {
+          "name": "pipeline_step_0",
+          "alias": "build",
+          "image": "tutum/curl:latest",
+          "working_dir": "/go/src/github.com/drone/envsubst",
+          "environment": {
+            "CI": "drone",
+            "CI_SCRIPT": "CmlmIFsgLW4gIiRDSV9ORVRSQ19NQUNISU5FIiBdOyB0aGVuCmNhdCA8PEVPRiA+ICRIT01FLy5uZXRyYwptYWNoaW5lICRDSV9ORVRSQ19NQUNISU5FCmxvZ2luICRDSV9ORVRSQ19VU0VSTkFNRQpwYXNzd29yZCAkQ0lfTkVUUkNfUEFTU1dPUkQKRU9GCmNobW9kIDA2MDAgJEhPTUUvLm5ldHJjCmZpCnVuc2V0IENJX05FVFJDX1VTRVJOQU1FCnVuc2V0IENJX05FVFJDX1BBU1NXT1JECnVuc2V0IENJX1NDUklQVAp1bnNldCBEUk9ORV9ORVRSQ19VU0VSTkFNRQp1bnNldCBEUk9ORV9ORVRSQ19QQVNTV09SRAoKZWNobyArICJjdXJsIC1zIC1mIC1MIGh0dHA6Ly9cJHtIT1NUfS9lbWJvZHkvIgpjdXJsIC1zIC1mIC1MIGh0dHA6Ly8ke0hPU1R9L2VtYm9keS8KCg==",
+            "CI_SYSTEM": "pipec",
+            "CI_SYSTEM_ARCH": "linux/amd64",
+            "CI_SYSTEM_LINK": "https://github.com/cncd/pipec",
+            "CI_SYSTEM_NAME": "pipec",
+            "CI_WORKSPACE": "/go/src/github.com/drone/envsubst",
+            "DRONE": "true",
+            "DRONE_ARCH": "linux/amd64",
+            "DRONE_BUILD_LINK": "https://github.com/cncd/pipec//0",
+            "DRONE_REPO_SCM": "git",
+            "DRONE_WORKSPACE": "/go/src/github.com/drone/envsubst",
+            "HOME": "/root",
+            "SHELL": "/bin/sh"
+          },
+          "entrypoint": [
+            "/bin/sh",
+            "-c"
+          ],
+          "command": [
+            "echo $CI_SCRIPT | base64 -d | /bin/sh -e"
+          ],
+          "volumes": [
+            "pipeline_default:/go"
+          ],
+          "networks": [
+            {
+              "name": "pipeline_default",
+              "aliases": [
+                "build"
+              ]
+            }
+          ],
+          "on_success": true,
+          "auth_config": {},
+          "network_mode": "container:${VPN}"
+        }
+      ]
+    }
+  ],
+  "networks": [
+    {
+      "name": "pipeline_default",
+      "driver": "bridge"
+    }
+  ],
+  "volumes": [
+    {
+      "name": "pipeline_default",
+      "driver": "local"
+    }
+  ],
+  "secrets": null
+}

--- a/samples/sample_8_network_mode/pipeline.yml
+++ b/samples/sample_8_network_mode/pipeline.yml
@@ -1,0 +1,17 @@
+workspace:
+  base: /go
+  path: src/github.com/drone/envsubst
+
+clone:
+  git:
+    image: plugins/git
+    depth: 50
+
+pipeline:
+  build:
+    image: tutum/curl
+    # A container named "vpn" should exist on the same docker daemon
+    network_mode: "container:vpn"
+    # Replace HOST_OR_IP with the IP or hostname of a server behind the VPN
+    commands:
+      - curl -s -f -L http://HOST_OR_IP/


### PR DESCRIPTION
With network mode we can reuse a network defined by another container (or the host itself), like a container connected
to a VPN. This is useful for the case that you should connect through a VPN to perform a deploy.

Because network_mode use an already created network, we can't use services on this build step. All custom networks
are disabled if network_mode is present.