### PR TITLE
Add support for mounting tmpfs to containers

### DIFF
--- a/pipeline/backend/docker/convert.go
+++ b/pipeline/backend/docker/convert.go
@@ -74,6 +74,15 @@ func toHostConfig(proc *backend.Step) *container.HostConfig {
 	if len(proc.Volumes) != 0 {
 		config.Binds = proc.Volumes
 	}
+	config.Tmpfs = map[string]string{}
+	for _, path := range proc.Tmpfs {
+		if strings.Index(path, ":") == -1 {
+			config.Tmpfs[path] = ""
+			continue
+		}
+		parts := strings.Split(path, ":")
+		config.Tmpfs[parts[0]] = parts[1]
+	}
 	// if proc.OomKillDisable {
 	// 	config.OomKillDisable = &proc.OomKillDisable
 	// }

--- a/pipeline/backend/types.go
+++ b/pipeline/backend/types.go
@@ -31,6 +31,7 @@ type (
 		Command      []string          `json:"command,omitempty"`
 		ExtraHosts   []string          `json:"extra_hosts,omitempty"`
 		Volumes      []string          `json:"volumes,omitempty"`
+		Tmpfs        []string          `json:"tmpfs,omitempty"`
 		Devices      []string          `json:"devices,omitempty"`
 		Networks     []Conn            `json:"networks,omitempty"`
 		DNS          []string          `json:"dns,omitempty"`

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -148,6 +148,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 		Command:      command,
 		ExtraHosts:   container.ExtraHosts,
 		Volumes:      volumes,
+		Tmpfs:        container.Tmpfs,
 		Devices:      container.Devices,
 		Networks:     networks,
 		DNS:          container.DNS,

--- a/pipeline/frontend/yaml/container.go
+++ b/pipeline/frontend/yaml/container.go
@@ -32,6 +32,7 @@ type (
 		CPUShares     libcompose.StringorInt    `yaml:"cpu_shares,omitempty"`
 		Detached      bool                      `yaml:"detach,omitempty"`
 		Devices       []string                  `yaml:"devices,omitempty"`
+		Tmpfs         []string                  `yaml:"tmpfs,omitempty"`
 		DNS           libcompose.Stringorslice  `yaml:"dns,omitempty"`
 		DNSSearch     libcompose.Stringorslice  `yaml:"dns_search,omitempty"`
 		Entrypoint    libcompose.Command        `yaml:"entrypoint,omitempty"`


### PR DESCRIPTION
_This is a port of the code from https://github.com/drone/drone/pull/1923_

This PR adds a `tmpfs` setting to the containers. The syntax is the same as in `docker-compose`.

You can specify tmpfs with the default mount options like this:
```
 services:
   postgres:
     image: postgres:9.6
     tmpfs:
     - /var/lib/postgresql/data
```
And you can specify mount options with `:` :
```
 services:
   postgres:
     image: postgres:9.6
     tmpfs:
     - /var/lib/postgresql/data:size=1G
```
This is useful for making tests faster if you are IO-bound.