### PR TITLE
Use hostname instead of host workspace from URL

### DIFF
--- a/pipeline/frontend/yaml/compiler/option.go
+++ b/pipeline/frontend/yaml/compiler/option.go
@@ -104,7 +104,7 @@ func WithWorkspaceFromURL(base, link string) Option {
 	path := "src"
 	parsed, err := url.Parse(link)
 	if err == nil {
-		path = filepath.Join(path, parsed.Host, parsed.Path)
+		path = filepath.Join(path, parsed.Hostname(), parsed.Path)
 	}
 	return WithWorkspace(base, path)
 }


### PR DESCRIPTION
The host could contain colon which should be avoided as it is often used
as path separator.