### PR TITLE
Close backend engine after execution

### DIFF
--- a/pipec/exec.go
+++ b/pipec/exec.go
@@ -86,6 +86,7 @@ func executeAction(c *cli.Context) (err error) {
 			return err
 		}
 	}
+	defer engine.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.Duration("timeout"))
 	defer cancel()

--- a/pipeline/backend/backend.go
+++ b/pipeline/backend/backend.go
@@ -18,4 +18,6 @@ type Engine interface {
 	Tail(*Step) (io.ReadCloser, error)
 	// Destroy the pipeline environment.
 	Destroy(*Config) error
+	// Close the engine
+	Close() error
 }

--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -15,11 +15,11 @@ import (
 )
 
 type engine struct {
-	client client.APIClient
+	client *client.Client
 }
 
 // New returns a new Docker Engine using the given client.
-func New(cli client.APIClient) backend.Engine {
+func New(cli *client.Client) backend.Engine {
 	return &engine{
 		client: cli,
 	}
@@ -181,6 +181,10 @@ func (e *engine) Destroy(conf *backend.Config) error {
 		e.client.NetworkRemove(noContext, network.Name)
 	}
 	return nil
+}
+
+func (e *engine) Close() error {
+	return e.client.Close()
 }
 
 var (

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -58,3 +58,7 @@ func (e *engine) Destroy(*backend.Config) error {
 	// DELETE /api/v1/namespaces/{name}
 	return nil
 }
+
+func (e *engine) Close() error {
+	return nil
+}


### PR DESCRIPTION
It is required to close docker client when it uses socket.
https://godoc.org/github.com/moby/moby/client#Client.Close