### PR TITLE
Add ability to not attach networks to a pipeline step

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -103,7 +103,7 @@ func (e *engine) Exec(proc *backend.Step) error {
 		return err
 	}
 
-	if len(proc.NetworkMode) == 0 {
+	if len(proc.NetworkMode) == 0 && !proc.DisableNetworks {
 		for _, net := range proc.Networks {
 			err = e.client.NetworkConnect(ctx, net.Name, proc.Name, &network.EndpointSettings{
 				Aliases: net.Aliases,

--- a/pipeline/backend/types.go
+++ b/pipeline/backend/types.go
@@ -18,34 +18,35 @@ type (
 
 	// Step defines a container process.
 	Step struct {
-		Name         string            `json:"name"`
-		Alias        string            `json:"alias,omitempty"`
-		Image        string            `json:"image,omitempty"`
-		Pull         bool              `json:"pull,omitempty"`
-		Detached     bool              `json:"detach,omitempty"`
-		Privileged   bool              `json:"privileged,omitempty"`
-		WorkingDir   string            `json:"working_dir,omitempty"`
-		Environment  map[string]string `json:"environment,omitempty"`
-		Labels       map[string]string `json:"labels,omitempty"`
-		Entrypoint   []string          `json:"entrypoint,omitempty"`
-		Command      []string          `json:"command,omitempty"`
-		ExtraHosts   []string          `json:"extra_hosts,omitempty"`
-		Volumes      []string          `json:"volumes,omitempty"`
-		Devices      []string          `json:"devices,omitempty"`
-		Networks     []Conn            `json:"networks,omitempty"`
-		DNS          []string          `json:"dns,omitempty"`
-		DNSSearch    []string          `json:"dns_search,omitempty"`
-		MemSwapLimit int64             `json:"memswap_limit,omitempty"`
-		MemLimit     int64             `json:"mem_limit,omitempty"`
-		ShmSize      int64             `json:"shm_size,omitempty"`
-		CPUQuota     int64             `json:"cpu_quota,omitempty"`
-		CPUShares    int64             `json:"cpu_shares,omitempty"`
-		CPUSet       string            `json:"cpu_set,omitempty"`
-		OnFailure    bool              `json:"on_failure,omitempty"`
-		OnSuccess    bool              `json:"on_success,omitempty"`
-		AuthConfig   Auth              `json:"auth_config,omitempty"`
-		NetworkMode  string            `json:"network_mode,omitempty"`
-		IpcMode      string            `json:"ipc_mode,omitempty"`
+		Name            string            `json:"name"`
+		Alias           string            `json:"alias,omitempty"`
+		Image           string            `json:"image,omitempty"`
+		Pull            bool              `json:"pull,omitempty"`
+		Detached        bool              `json:"detach,omitempty"`
+		Privileged      bool              `json:"privileged,omitempty"`
+		WorkingDir      string            `json:"working_dir,omitempty"`
+		Environment     map[string]string `json:"environment,omitempty"`
+		Labels          map[string]string `json:"labels,omitempty"`
+		Entrypoint      []string          `json:"entrypoint,omitempty"`
+		Command         []string          `json:"command,omitempty"`
+		ExtraHosts      []string          `json:"extra_hosts,omitempty"`
+		Volumes         []string          `json:"volumes,omitempty"`
+		Devices         []string          `json:"devices,omitempty"`
+		Networks        []Conn            `json:"networks,omitempty"`
+		DNS             []string          `json:"dns,omitempty"`
+		DNSSearch       []string          `json:"dns_search,omitempty"`
+		MemSwapLimit    int64             `json:"memswap_limit,omitempty"`
+		MemLimit        int64             `json:"mem_limit,omitempty"`
+		ShmSize         int64             `json:"shm_size,omitempty"`
+		CPUQuota        int64             `json:"cpu_quota,omitempty"`
+		CPUShares       int64             `json:"cpu_shares,omitempty"`
+		CPUSet          string            `json:"cpu_set,omitempty"`
+		OnFailure       bool              `json:"on_failure,omitempty"`
+		OnSuccess       bool              `json:"on_success,omitempty"`
+		AuthConfig      Auth              `json:"auth_config,omitempty"`
+		DisableNetworks bool              `json:"disable_networks,omitempty"`
+		NetworkMode     string            `json:"network_mode,omitempty"`
+		IpcMode         string            `json:"ipc_mode,omitempty"`
 	}
 
 	// Auth defines registry authentication credentials.

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -14,13 +14,14 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 		detached   bool
 		workingdir string
 
-		workspace    = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
-		privileged   = container.Privileged
-		entrypoint   = container.Entrypoint
-		command      = container.Command
-		image        = expandImage(container.Image)
-		network_mode = container.NetworkMode
-		ipc_mode     = container.IpcMode
+		workspace       = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
+		privileged      = container.Privileged
+		entrypoint      = container.Entrypoint
+		command         = container.Command
+		image           = expandImage(container.Image)
+		disableNetworks = container.DisableNetworks
+		network_mode    = container.NetworkMode
+		ipc_mode        = container.IpcMode
 		// network    = container.Network
 	)
 
@@ -164,6 +165,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 		OnFailure: (len(container.Constraints.Status.Include)+
 			len(container.Constraints.Status.Exclude) != 0) &&
 			container.Constraints.Status.Match("failure"),
+		DisableNetworks: disableNetworks,
 		NetworkMode: network_mode,
 		IpcMode:     ipc_mode,
 	}

--- a/pipeline/frontend/yaml/config_test.go
+++ b/pipeline/frontend/yaml/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/franela/goblin"
 )
 
-func xTestParse(t *testing.T) {
+func TestParse(t *testing.T) {
 	g := goblin.Goblin(t)
 
 	g.Describe("Parser", func() {
@@ -32,10 +32,15 @@ func xTestParse(t *testing.T) {
 				g.Assert(out.Pipeline.Containers[0].Commands).Equal(yaml.Stringorslice{"go install", "go test"})
 				g.Assert(out.Pipeline.Containers[1].Name).Equal("build")
 				g.Assert(out.Pipeline.Containers[1].Image).Equal("golang")
+				g.Assert(out.Pipeline.Containers[1].NetworkMode).Equal("container:name")
+				g.Assert(out.Pipeline.Containers[1].DisableNetworks).Equal(false)
 				g.Assert(out.Pipeline.Containers[1].Commands).Equal(yaml.Stringorslice{"go build"})
-				g.Assert(out.Pipeline.Containers[2].Name).Equal("notify")
-				g.Assert(out.Pipeline.Containers[2].Image).Equal("slack")
-				g.Assert(out.Pipeline.Containers[2].NetworkMode).Equal("container:name")
+				g.Assert(out.Pipeline.Containers[2].Name).Equal("docker")
+				g.Assert(out.Pipeline.Containers[2].Image).Equal("plugins/docker")
+				g.Assert(out.Pipeline.Containers[2].DisableNetworks).Equal(true)
+				g.Assert(out.Pipeline.Containers[3].Name).Equal("notify")
+				g.Assert(out.Pipeline.Containers[3].Image).Equal("slack")
+				g.Assert(out.Pipeline.Containers[3].DisableNetworks).Equal(false)
 				g.Assert(out.Labels["com.example.team"]).Equal("frontend")
 				g.Assert(out.Labels["com.example.type"]).Equal("build")
 			})
@@ -76,6 +81,15 @@ pipeline:
     commands:
       - go build
     when:
+      event: push
+  docker:
+    image: plugins/docker
+    repo: drone/drone
+    secrets: [ docker_username, docker_password ]
+    tag: [ latest ]
+    disable_networks: true
+    when:
+      branch: master
       event: push
   notify:
     image: slack

--- a/pipeline/frontend/yaml/container.go
+++ b/pipeline/frontend/yaml/container.go
@@ -22,40 +22,41 @@ type (
 
 	// Container defines a container.
 	Container struct {
-		AuthConfig    AuthConfig                `yaml:"auth_config,omitempty"`
-		CapAdd        []string                  `yaml:"cap_add,omitempty"`
-		CapDrop       []string                  `yaml:"cap_drop,omitempty"`
-		Command       libcompose.Command        `yaml:"command,omitempty"`
-		Commands      libcompose.Stringorslice  `yaml:"commands,omitempty"`
-		CPUQuota      libcompose.StringorInt    `yaml:"cpu_quota,omitempty"`
-		CPUSet        string                    `yaml:"cpuset,omitempty"`
-		CPUShares     libcompose.StringorInt    `yaml:"cpu_shares,omitempty"`
-		Detached      bool                      `yaml:"detach,omitempty"`
-		Devices       []string                  `yaml:"devices,omitempty"`
-		DNS           libcompose.Stringorslice  `yaml:"dns,omitempty"`
-		DNSSearch     libcompose.Stringorslice  `yaml:"dns_search,omitempty"`
-		Entrypoint    libcompose.Command        `yaml:"entrypoint,omitempty"`
-		Environment   libcompose.SliceorMap     `yaml:"environment,omitempty"`
-		ExtraHosts    []string                  `yaml:"extra_hosts,omitempty"`
-		Group         string                    `yaml:"group,omitempty"`
-		Image         string                    `yaml:"image,omitempty"`
-		Isolation     string                    `yaml:"isolation,omitempty"`
-		Labels        libcompose.SliceorMap     `yaml:"labels,omitempty"`
-		MemLimit      libcompose.MemStringorInt `yaml:"mem_limit,omitempty"`
-		MemSwapLimit  libcompose.MemStringorInt `yaml:"memswap_limit,omitempty"`
-		MemSwappiness libcompose.MemStringorInt `yaml:"mem_swappiness,omitempty"`
-		Name          string                    `yaml:"name,omitempty"`
-		NetworkMode   string                    `yaml:"network_mode,omitempty"`
-		IpcMode       string                    `yaml:"ipc_mode,omitempty"`
-		Networks      libcompose.Networks       `yaml:"networks,omitempty"`
-		Privileged    bool                      `yaml:"privileged,omitempty"`
-		Pull          bool                      `yaml:"pull,omitempty"`
-		ShmSize       libcompose.MemStringorInt `yaml:"shm_size,omitempty"`
-		Ulimits       libcompose.Ulimits        `yaml:"ulimits,omitempty"`
-		Volumes       libcompose.Volumes        `yaml:"volumes,omitempty"`
-		Secrets       Secrets                   `yaml:"secrets,omitempty"`
-		Constraints   Constraints               `yaml:"when,omitempty"`
-		Vargs         map[string]interface{}    `yaml:",inline"`
+		AuthConfig      AuthConfig                `yaml:"auth_config,omitempty"`
+		CapAdd          []string                  `yaml:"cap_add,omitempty"`
+		CapDrop         []string                  `yaml:"cap_drop,omitempty"`
+		Command         libcompose.Command        `yaml:"command,omitempty"`
+		Commands        libcompose.Stringorslice  `yaml:"commands,omitempty"`
+		CPUQuota        libcompose.StringorInt    `yaml:"cpu_quota,omitempty"`
+		CPUSet          string                    `yaml:"cpuset,omitempty"`
+		CPUShares       libcompose.StringorInt    `yaml:"cpu_shares,omitempty"`
+		Detached        bool                      `yaml:"detach,omitempty"`
+		Devices         []string                  `yaml:"devices,omitempty"`
+		DNS             libcompose.Stringorslice  `yaml:"dns,omitempty"`
+		DNSSearch       libcompose.Stringorslice  `yaml:"dns_search,omitempty"`
+		Entrypoint      libcompose.Command        `yaml:"entrypoint,omitempty"`
+		Environment     libcompose.SliceorMap     `yaml:"environment,omitempty"`
+		ExtraHosts      []string                  `yaml:"extra_hosts,omitempty"`
+		Group           string                    `yaml:"group,omitempty"`
+		Image           string                    `yaml:"image,omitempty"`
+		Isolation       string                    `yaml:"isolation,omitempty"`
+		Labels          libcompose.SliceorMap     `yaml:"labels,omitempty"`
+		MemLimit        libcompose.MemStringorInt `yaml:"mem_limit,omitempty"`
+		MemSwapLimit    libcompose.MemStringorInt `yaml:"memswap_limit,omitempty"`
+		MemSwappiness   libcompose.MemStringorInt `yaml:"mem_swappiness,omitempty"`
+		Name            string                    `yaml:"name,omitempty"`
+		DisableNetworks bool                      `yaml:"disable_networks,omitempty"`
+		NetworkMode     string                    `yaml:"network_mode,omitempty"`
+		IpcMode         string                    `yaml:"ipc_mode,omitempty"`
+		Networks        libcompose.Networks       `yaml:"networks,omitempty"`
+		Privileged      bool                      `yaml:"privileged,omitempty"`
+		Pull            bool                      `yaml:"pull,omitempty"`
+		ShmSize         libcompose.MemStringorInt `yaml:"shm_size,omitempty"`
+		Ulimits         libcompose.Ulimits        `yaml:"ulimits,omitempty"`
+		Volumes         libcompose.Volumes        `yaml:"volumes,omitempty"`
+		Secrets         Secrets                   `yaml:"secrets,omitempty"`
+		Constraints     Constraints               `yaml:"when,omitempty"`
+		Vargs           map[string]interface{}    `yaml:",inline"`
 	}
 )
 


### PR DESCRIPTION
This provides the ability to not attach pipeline networks to a step, e.g.

```diff
pipeline:
  docker:
    image: plugins/docker
    repo: drone/drone
    secrets: [ docker_username, docker_password ]
    tag: [ latest ]
+   disable_networks: true
```

This is in support of https://github.com/drone/drone/issues/2132