### PR TITLE
Add human readable build timestamp in environment variables

### DIFF
--- a/pipeline/frontend/metadata.go
+++ b/pipeline/frontend/metadata.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Event types corresponding to scm hooks.
@@ -107,6 +108,9 @@ func (m *Metadata) Environ() map[string]string {
 		"CI_BUILD_CREATED":             strconv.FormatInt(m.Curr.Created, 10),
 		"CI_BUILD_STARTED":             strconv.FormatInt(m.Curr.Started, 10),
 		"CI_BUILD_FINISHED":            strconv.FormatInt(m.Curr.Finished, 10),
+		"CI_BUILD_CREATED_DATE":        time.Unix(m.Curr.Created, 0).Format("20060102-150405"),
+		"CI_BUILD_STARTED_DATE":        time.Unix(m.Curr.Started, 0).Format("20060102-150405"),
+		"CI_BUILD_FINISHED_DATE":       time.Unix(m.Curr.Finished, 0).Format("20060102-150405"),
 		"CI_BUILD_STATUS":              m.Curr.Status,
 		"CI_BUILD_EVENT":               m.Curr.Event,
 		"CI_BUILD_LINK":                m.Curr.Link,
@@ -202,6 +206,9 @@ func (m *Metadata) EnvironDrone() map[string]string {
 		"DRONE_BUILD_CREATED":        fmt.Sprintf("%d", m.Curr.Created),
 		"DRONE_BUILD_STARTED":        fmt.Sprintf("%d", m.Curr.Started),
 		"DRONE_BUILD_FINISHED":       fmt.Sprintf("%d", m.Curr.Finished),
+		"DRONE_BUILD_CREATED_DATE":   time.Unix(m.Curr.Created, 0).Format("20060102-150405"),
+		"DRONE_BUILD_STARTED_DATE":   time.Unix(m.Curr.Started, 0).Format("20060102-150405"),
+		"DRONE_BUILD_FINISHED_DATE":  time.Unix(m.Curr.Finished, 0).Format("20060102-150405"),
 		"DRONE_JOB_NUMBER":           fmt.Sprintf("%d", m.Job.Number),
 		"DRONE_JOB_STARTED":          fmt.Sprintf("%d", m.Curr.Started), // ISSUE: no job started
 		"DRONE_BRANCH":               m.Curr.Commit.Branch,


### PR DESCRIPTION
Hello,

I need a human readable date in the environment variables.

The purpose of this, is to tag the our generated docker image with a human readable timestamp to be sure of which image is going to be deployed.

Here is what is currently used:
```
  publish-preprod-img:
    image: plugins/gcr
    when:
      branch: master
      event: push
    repo: preprod/transport
    tags: [ latest, "${DRONE_BUILD_CREATED}-${DRONE_COMMIT_SHA}" ]
    secrets: [ google_credentials ]
    context: release/
    dockerfile: /go/src/release/Dockerfile
    registry: eu.gcr.io
```

I have tried to use a custom environment variable, but it doesn't seem to be possible. 
```
environment:
    - BUILD_DATE=$(date +%Y%m%d)
```
Got:  An empty string

```
commands:
    export BUILD_DATE=$(date +%Y%m%d)
```
Got: `Cannot configure both commands and custom attributes [dockerfile registry repo tags context]`

```
tags: [ test, "$(date +%Y%m%d)-${DRONE_COMMIT_SHA}" ]
```
Got: `Error parsing reference: "eu.gcr.io/preprod/transport:$(date +%Y%m%d)-`

Also, I think that a human readable timestamp can be useful in other cases for other people.

