### PR TITLE
Support docker network's CheckDuplicate

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -49,8 +49,9 @@ func (e *engine) Setup(_ context.Context, conf *backend.Config) error {
 	}
 	for _, network := range conf.Networks {
 		_, err := e.client.NetworkCreate(noContext, network.Name, types.NetworkCreate{
-			Driver:  network.Driver,
-			Options: network.DriverOpts,
+			Driver:         network.Driver,
+			Options:        network.DriverOpts,
+			CheckDuplicate: network.CheckDuplicate,
 			// Labels:  defaultLabels,
 		})
 		if err != nil {

--- a/pipeline/backend/types.go
+++ b/pipeline/backend/types.go
@@ -65,9 +65,10 @@ type (
 
 	// Network defines a container network.
 	Network struct {
-		Name       string            `json:"name,omitempty"`
-		Driver     string            `json:"driver,omitempty"`
-		DriverOpts map[string]string `json:"driver_opts,omitempty"`
+		Name           string            `json:"name,omitempty"`
+		Driver         string            `json:"driver,omitempty"`
+		DriverOpts     map[string]string `json:"driver_opts,omitempty"`
+		CheckDuplicate bool              `json:"check_duplicate,omitempty"`
 	}
 
 	// Volume defines a container volume.


### PR DESCRIPTION
https://godoc.org/github.com/docker/docker/api/types#NetworkCreate
https://github.com/moby/moby/issues/18864

Allow to set Docker network's CheckDuplicate option
to prevent name's collisions.