### PR TITLE
Value of httpProxy to be read from http_proxy

### DIFF
--- a/pipeline/frontend/yaml/compiler/option.go
+++ b/pipeline/frontend/yaml/compiler/option.go
@@ -231,7 +231,7 @@ func WithResourceLimit(swap, mem, shmsize, cpuQuota, cpuShares int64, cpuSet str
 
 var (
 	noProxy    = getenv("no_proxy")
-	httpProxy  = getenv("https_proxy")
+	httpProxy  = getenv("http_proxy")
 	httpsProxy = getenv("https_proxy")
 )
 


### PR DESCRIPTION
Switch from using environmental variable https_proxy to http_proxy for
finding our value for httpProxy.